### PR TITLE
SVCB-HTTPS fixes for uniqueness and ordering

### DIFF
--- a/str2host.c
+++ b/str2host.c
@@ -1870,15 +1870,16 @@ ldns_svcbparams_insert_new(ldns_svcbparams_data **head, uint16_t key)
 
 // Free all elements and their data in the list
 void
-ldns_svcbparams_free(ldns_svcbparams_data *head)
+ldns_svcbparams_free(ldns_svcbparams_data **head)
 {
-	ldns_svcbparams_data *curr = head;
+	ldns_svcbparams_data *curr = *head;
 	while (curr != NULL) {
 		ldns_svcbparams_data *tmp = curr;
 		curr = curr->next;
 		LDNS_FREE(tmp->data);
 		LDNS_FREE(tmp);
 	}
+	*head = NULL;
 }
 
 ldns_status
@@ -2023,7 +2024,7 @@ ldns_str2rdf_svcbparams(ldns_rdf **rd, const char *str)
 				ldns_write_uint16(datap, curr->key);
 				datap += 2;
 			}
-			ldns_svcbparams_free(mandatory);
+			ldns_svcbparams_free(&mandatory);
 		} else if (key == 1) {
 			// alpn has comma separated list of strings (allowing escaped byte sequences)
 			char *start = val_str;
@@ -2158,7 +2159,7 @@ ldns_str2rdf_svcbparams(ldns_rdf **rd, const char *str)
 	*rd = ldns_rdf_new_frm_data(LDNS_RDF_TYPE_SVCBPARAMS, (uint16_t) params_len, data);
 
 	ldns_buffer_free(str_buf);
-	ldns_svcbparams_free(params);
+	ldns_svcbparams_free(&params);
 	LDNS_FREE(token);
 	LDNS_FREE(data);
 	if(!*rd) return LDNS_STATUS_MEM_ERR;
@@ -2166,8 +2167,8 @@ ldns_str2rdf_svcbparams(ldns_rdf **rd, const char *str)
 
 error:
 	ldns_buffer_free(str_buf);
-	ldns_svcbparams_free(params);
-	ldns_svcbparams_free(mandatory);
+	ldns_svcbparams_free(&params);
+	ldns_svcbparams_free(&mandatory);
 	LDNS_FREE(token);
 	LDNS_FREE(data);
 	LDNS_FREE(key_str);

--- a/test/08-zonereader.tpkg/08-zonereader.inputzone
+++ b/test/08-zonereader.tpkg/08-zonereader.inputzone
@@ -3891,6 +3891,7 @@ svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. alpn="h2,h3"
 svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. alpn=h2\,h3,h4
 svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. mandatory=alpn
 svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. mandatory=alpn,no-default-alpn
+svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. mandatory=ipv4hint,port,alpn,key1234
 svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. mandatory=alpn,no-default-alpn alpn=h2,h3 no-default-alpn
 svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. port=1234
 svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. port=1234 alpn=h2,h3
@@ -3909,6 +3910,7 @@ svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. key12345=abc\
 svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. alpn=h2,h3 key33=\000\001\002
 svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. alpn=h2,h3 key1000="\a\bc123" port=1234
 svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. alpn=h2,h3 key10000 port=1234
+svcb-service.nlnetlabs.nl.      3600    IN      SVCB    1 foo.com. alpn=h2,h3 ipv4hint=1.2.3.4 key33=\000\001 port=1234
 svcb-service.nlnetlabs.nl.	    3600	IN      SVCB    1 . alpn=h2\,h3,h\\4
 svcb-service.nlnetlabs.nl.	    3600	IN      SVCB    1 . alpn=http/1.1,\001aa\003b,h2 port=8443
 svcb-service.nlnetlabs.nl.	    3600	IN      SVCB    1 . key10=aa\005b\bb

--- a/test/08-zonereader.tpkg/08-zonereader.outputzone
+++ b/test/08-zonereader.tpkg/08-zonereader.outputzone
@@ -3891,24 +3891,26 @@ svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2,h3
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2\,h3,h4
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. mandatory=alpn
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. mandatory=alpn,no-default-alpn
+svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. mandatory=alpn,port,ipv4hint,key1234
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. mandatory=alpn,no-default-alpn alpn=h2,h3 no-default-alpn
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. port=1234
-svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. port=1234 alpn=h2,h3
-svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. mandatory=alpn port=555 alpn=h2,h3
+svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2,h3 port=1234
+svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. mandatory=alpn alpn=h2,h3 port=555
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. ipv4hint=1.2.3.4
-svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. ipv4hint=1.2.3.4,5.6.7.8 port=1234
+svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. port=1234 ipv4hint=1.2.3.4,5.6.7.8
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. ipv4hint=1.2.3.4,5.6.7.8
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2 ipv4hint=4.5.6.7
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. echconfig=1234
-svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. echconfig=1234 alpn=h2,h3
+svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2,h3 echconfig=1234
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2 ipv4hint=4.5.6.7 echconfig=zzzz
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. ipv6hint=2001:2002::1
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2,h3 ipv6hint=2001::1,2001::2
-svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. mandatory=alpn ipv6hint=2001::1,2001::2 alpn=h2,h3
+svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. mandatory=alpn alpn=h2,h3 ipv6hint=2001::1,2001::2
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. key12345=abcdefg\012hijk\005\004lmn
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2,h3 key33=\000\001\002
-svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2,h3 key1000=abc123 port=1234
-svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2,h3 key10000 port=1234
+svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2,h3 port=1234 key1000=abc123
+svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2,h3 port=1234 key10000
+svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 foo.com. alpn=h2,h3 port=1234 ipv4hint=1.2.3.4 key33=\000\001
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 . alpn=h2\,h3,h\\4
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 . alpn=http/1.1,\001aa\003b,h2 port=8443
 svcb-service.nlnetlabs.nl.	3600	IN	SVCB	1 . key10=aa\005bbb


### PR DESCRIPTION
Ensure that SVCB/HTTPS parameter keys are properly ordered and unique when parse from text.
Also ensure that keys listed for the mandatory parameter are properly ordered, unique, and mandatory itself is not listed.